### PR TITLE
add types for crd implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 vendor
 *~
 *.pyc
+*.idea

--- a/go/glide.lock
+++ b/go/glide.lock
@@ -1,5 +1,5 @@
-hash: 68f2ea1e94337de23ced934e5329705b86d854bf8be2ac2781bf06ff54fe2732
-updated: 2017-10-26T21:56:48.987012103Z
+hash: 50f1deb70494c2eec4c862f9c9651163931f0268585a8f11670bd52e530d12c1
+updated: 2018-01-09T00:37:44.855693+08:00
 imports:
 - name: github.com/bitly/go-simplejson
   version: aabad6e819789e569bd6aabf444c935aa9ba1e44
@@ -26,7 +26,7 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 84b5bee7bcb76f3d17bcbaf421bac44bd5709ca6
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/go-stack/stack
@@ -45,7 +45,7 @@ imports:
 - name: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/gorilla/mux
-  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
+  version: 7f08801859139f86dfafd1c296e2cba9a80d292e
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
@@ -69,7 +69,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/spf13/pflag
-  version: 97afa5e7ca8a08a383cb259e06636b5e2cc7897f
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -81,8 +81,6 @@ imports:
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
-  - context
-  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -234,10 +232,8 @@ imports:
   - util/flowcontrol
   - util/homedir
   - util/integer
-- name: k8s.io/kube-openapi
-  version: 61b46af70dfed79c6d24530cd23b41440a7f22a5
-  subpackages:
-  - pkg/common
+- name: k8s.io/code-generator
+  version: 25fd8c8ddbf75b223882df4479f8b8e615da05ae
 - name: k8s.io/kubernetes
   version: d6f433224538d4f9ca2f7ae19b252e6fcb66a3ae
   subpackages:

--- a/go/glide.yaml
+++ b/go/glide.yaml
@@ -18,3 +18,5 @@ import:
   version: v2.13
 - package: github.com/go-stack/stack
   version: v1.6.0
+- package: k8s.io/code-generator
+  version: kubernetes-1.8.5

--- a/go/hack/update-codegen.sh
+++ b/go/hack/update-codegen.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell is used to auto generate some useful tools for k8s, such as lister,
+# informer, deepcopy, defaulter and so on.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+echo ${SCRIPT_ROOT}
+CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+echo ${CODEGEN_PKG}
+
+# generate the code with:
+# --output-base    because this script should also be able to run inside the vendor dir of
+#                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
+#                  instead of the $GOPATH directly. For normal projects this can be dropped.
+${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+ github.com/PaddlePaddle/cloud/go/pkg/client github.com/PaddlePaddle/cloud/go/pkg/apis \
+  paddlepaddle:v1alpha1
+

--- a/go/hack/verify-codegen.sh
+++ b/go/hack/verify-codegen.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+DIFFROOT="${SCRIPT_ROOT}/pkg"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
+_tmp="${SCRIPT_ROOT}/_tmp"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+
+"${SCRIPT_ROOT}/hack/update-codegen.sh"
+echo "diffing ${DIFFROOT} against freshly generated codegen"
+ret=0
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+  exit 1
+fi

--- a/go/pkg/apis/paddlepaddle/register.go
+++ b/go/pkg/apis/paddlepaddle/register.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2016 PaddlePaddle Authors All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package paddlepaddle
+
+const (
+	GroupName = "paddlepaddle.org"
+)

--- a/go/pkg/apis/paddlepaddle/v1alpha1/doc.go
+++ b/go/pkg/apis/paddlepaddle/v1alpha1/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2016 PaddlePaddle Authors All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:deepcopy-gen=package
+
+// Package v1alpha1 is the v1alpha1 version of the API.
+// +groupName=paddlepaddle.org
+package v1alpha1

--- a/go/pkg/apis/paddlepaddle/v1alpha1/register.go
+++ b/go/pkg/apis/paddlepaddle/v1alpha1/register.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+// SchemeGroupVersion is the group version used to register these objects.
+var SchemeGroupVersion = schema.GroupVersion{Group: CRDGroup, Version: CRDVersion}
+
+// Resource takes an unqualified resource and returns a Group-qualified GroupResource.
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+// addKnownTypes adds the set of types defined in this package to the supplied scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&TrainingJob{},
+		&TrainingJobList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/go/pkg/apis/paddlepaddle/v1alpha1/types.go
+++ b/go/pkg/apis/paddlepaddle/v1alpha1/types.go
@@ -1,0 +1,90 @@
+package v1alpha1
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	CRDKind       = "TraingingJob"
+	CRDKindPlural = "traingingjobs"
+	CRDGroup      = "paddlepaddle.org"
+	CRDVersion    = "v1alpha1"
+)
+
+// CRDName returns name of crd
+func CRDName() string {
+	return fmt.Sprintf("%s.%s", CRDKindPlural, CRDGroup)
+}
+
+// +genclient
+// +genclient:noStatus
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=trainingjob
+
+// TrainingJob is a specification for a TrainingJob resource
+type TrainingJob struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              TrainingJobSpec   `json:"spec"`
+	Status            TrainingJobStatus `json:"status"`
+}
+
+// TrainingJobSpec is the spec for a TrainingJob resource
+type TrainingJobSpec struct {
+	// General job attributes.
+	Image             string              `json:"image,omitempty"`
+	Port              int                 `json:"port,omitempty"`
+	PortsNum          int                 `json:"ports_num,omitempty"`
+	PortsNumForSparse int                 `json:"ports_num_for_sparse,omitempty"`
+	FaultTolerant     bool                `json:"fault_tolerant,omitempty"`
+	Passes            int                 `json:"passes,omitempty"`
+	Volumes           []apiv1.Volume      `json:"volumes"`
+	VolumeMounts      []apiv1.VolumeMount `json:"VolumeMounts"`
+	//TrainingJob components.
+	Master  MasterSpec  `json:"master"`
+	Pserver PserverSpec `json:"pserver"`
+	Trainer TrainerSpec `json:"trainer"`
+}
+
+// MasterSpec is the spec for a master in the paddle job
+type MasterSpec struct {
+	EtcdEndpoint string                     `json:"etcd-endpoint"`
+	Resources    apiv1.ResourceRequirements `json:"resources"`
+}
+
+// PserverSpec is the spec for pservers in the paddle job
+type PserverSpec struct {
+	MinInstance int                        `json:"min-instance"`
+	MaxInstance int                        `json:"max-instance"`
+	Resources   apiv1.ResourceRequirements `json:"resources"`
+}
+
+// TrainerSpec is the spec for trainers in the paddle job
+type TrainerSpec struct {
+	EtcdEndpoint string                     `json:"etcd-endpoint"`
+	Entrypoint   string                     `json:"entrypoint"`
+	Workspace    string                     `json:"workspace"`
+	MinInstance  int                        `json:"min-instance"`
+	MaxInstance  int                        `json:"max-instance"`
+	Resources    apiv1.ResourceRequirements `json:"resources"`
+}
+
+// TrainingJobStatus is the status for a TrainingJob resource
+type TrainingJobStatus struct {
+	// TODO define the status of paddle training job
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=trainingjobs
+
+// TrainingJobList is a list of TrainingJob resources
+type TrainingJobList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	// Items means the list of paddle job/TrainingJob
+	Items []TrainingJob `json:"items"`
+}


### PR DESCRIPTION
To support CRD, I add the types for apis and they stay the same with original ones basically. The changes include:
1. change the job name `TrainingJob` to `PdJob`, because `TrainingJob` is too common and easy to conflict.
2. leave the definition of job status to @qizheng09 to implement.

plz review the codes @typhoonzero @Yancey1989 